### PR TITLE
Fixing Dockerfile build issues

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,7 @@
-FROM ubuntu
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND="noninteractive"
+ENV TZ="America/New_York"
 
 RUN dpkg --add-architecture i386 \
     && apt update \

--- a/readme.md
+++ b/readme.md
@@ -14,12 +14,14 @@ cd V-Rising-Docker-Linux
 
 4. Move all the files in /settings/ to some location.
 
-4. Build the image
+5. Update `ENV TZ="America/New_York"` in `dockerfile` to [your timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+
+6. Build the image
 sudo docker build . -t vrising:latest
 
-5. Modify docker compose, set a path for where you want your saves. Set the save and settings directories
+7. Modify docker compose, set a path for where you want your saves. Set the save and settings directories
 
-6. compose
+8. compose
 sudo docker-compose up -d 
 
 Really messy setup but this was the only way I could figure out how to work it lol. Never used Wine before. Hope for a native linux server soon! 


### PR DESCRIPTION
When running the `docker build` step, I ran into the same issue mentioned in #1. Pinning the Ubuntu version @ 20.04 seemed to fix the issue, and that also addresses #2. I then ran into an issue where one of the `apt` packages was installing `tzdata` which had an interactive prompt for inputting your timezone, so I added environment variables to ensure that prompt doesn't appear as well as README instructions to edit the environment variable to the reader's timezone.

Summary:
* Pinned Dockerfile's Ubuntu version to 20.04
* Added `DEBIAN_FRONTEND="noninteractive"` and `TZ` environment variables